### PR TITLE
Abstracted utils and removed ghost imports

### DIFF
--- a/src/fuzzy_match_jobs_durations.py
+++ b/src/fuzzy_match_jobs_durations.py
@@ -6,7 +6,6 @@ current_path = os.path.dirname(os.path.abspath(__file__))
 parent_path = os.path.abspath(os.path.join(current_path, ".."))
 sys.path.append(parent_path)
 
-from db_sync import db_sync
 from logger import setup_logging
 from tqdm import tqdm
 from rapidfuzz import process, fuzz

--- a/src/fuzzy_match_salary.py
+++ b/src/fuzzy_match_salary.py
@@ -13,56 +13,15 @@ from utils import (
     merge_and_cleanup_batches,
     upload_parquet_and_remove_local,
     get_most_recent_file,
+    posting_dates_handler,
+    apply_limit_to_matches
 )
-from db_sync import db_sync
 from tqdm import tqdm
 from rapidfuzz import process, fuzz
-from datetime import datetime, timedelta
 import polars as pl
 import numpy as np
 
 logger = setup_logging()
-
-def posting_dates_handler(jobs, posting_key, until_key, date_fmt):
-    null_value_fallback = 30
-
-    for row_dict in jobs:
-        if row_dict.get(until_key):
-            continue
-
-        posting_value = row_dict.get(posting_key)
-        if not posting_value:
-            continue
-
-        try:
-            posting_datetime = datetime.strptime(posting_value, "%Y-%m-%dT%H:%M:%S")
-        except Exception:
-            # minimal handling: skip non-matching strings
-            continue
-
-        row_dict[until_key] = (posting_datetime + timedelta(days=null_value_fallback)).strftime(date_fmt).upper()
-
-    result = jobs
-    return result
-
-
-def apply_limit_to_matches(matches_by_job, jobs_data, payroll_data, limit, output_buffer):
-    for job_index, match_list in matches_by_job.items():
-        # lambda is an anonymous function that takes 1 tuple (x) and returns the second element (x[1])
-        match_list = sorted(match_list, key=lambda x: x[1], reverse=True)[:limit]
-        job_row = jobs_data[job_index]
-        for payroll_index_global, match_score in match_list:
-            payroll_row = payroll_data[payroll_index_global]
-            payroll_salary = payroll_row["base_salary"]
-            job_salary_min = job_row["salary_range_from"]
-            job_salary_max = job_row["salary_range_to"]
-            if (
-                payroll_salary is not None
-                and job_salary_min is not None
-                and job_salary_max is not None
-                and job_salary_min <= payroll_salary <= job_salary_max
-            ):
-                output_buffer.append({**job_row, **payroll_row, "score": match_score})
 
 
 def fuzzy_match_payroll_to_jobs_vectorized(


### PR DESCRIPTION
# Description

This pull request refactors the handling of utility functions by moving `posting_dates_handler` and `apply_limit_to_matches` from `src/fuzzy_match_salary.py` into the shared `src/utils.py` module. This change improves code organization and reuse. Additionally, imports are updated across files to reflect these changes.

**Utility function refactoring:**

* Moved the `posting_dates_handler` and `apply_limit_to_matches` functions from `src/fuzzy_match_salary.py` to `src/utils.py`, centralizing shared logic for better maintainability. [[1]](diffhunk://#diff-5b9b94344593aee21cedb04caad2f5ed4ae296ea362bf72feda907a897f06373R16-L66) [[2]](diffhunk://#diff-51246e53255db77c9edad496f074aa1bdbf8dbdc11f89a02040115c9ab4fa7f0R118-R158)

**Import updates:**

* Updated imports in `src/fuzzy_match_salary.py` to import the moved functions from `src/utils.py` instead of defining them locally.
* Added necessary imports for `datetime` and `timedelta` in `src/utils.py` to support the moved functions.
* Cleaned up unused imports in `src/fuzzy_match_jobs_durations.py` after utility function relocation.


## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Chore
